### PR TITLE
fix: use go 1.16 in codeql build

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: "^1.16"
+        id: go
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1


### PR DESCRIPTION
seems to be defaulting to 1.15 which is too old